### PR TITLE
Update harvest.json

### DIFF
--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -415,9 +415,10 @@
   {
     "id": "arachnid_tainted",
     "type": "harvest",
+    "message": "You carefully crack open its exoskeleton to get at the flesh beneath",
     "entries": [
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.33 },
-      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.1 }
+      { "drop": "chitin_piece", "type": "skin", "mass_ratio": 0.1 }
     ]
   },
   {
@@ -426,7 +427,7 @@
     "message": "You laboriously dissect the colossal insect.",
     "entries": [
       { "drop": "mutant_meat", "base_num": [ 40, 55 ], "scale_num": [ 0.5, 0.7 ], "max": 80, "type": "flesh" },
-      { "drop": "acidchitin_piece", "base_num": [ 2, 6 ], "scale_num": [ 0.3, 0.6 ], "max": 10, "type": "bone" },
+      { "drop": "acidchitin_piece", "base_num": [ 2, 6 ], "scale_num": [ 0.3, 0.6 ], "max": 10, "type": "skin" },
       { "drop": "sweetbread", "base_num": [ 3, 4 ], "scale_num": [ 0.4, 0.6 ], "max": 8, "type": "offal" },
       { "drop": "mutant_fat", "base_num": [ 5, 8 ], "scale_num": [ 0.6, 0.8 ], "max": 18, "type": "flesh" }
     ]
@@ -434,41 +435,45 @@
   {
     "id": "arachnid",
     "type": "harvest",
+    "message": "You carefully crack open its exoskeleton to get at the flesh beneath",
     "entries": [
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.33 },
       { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.04 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.01 },
-      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.1 }
+      { "drop": "chitin_piece", "type": "skin", "mass_ratio": 0.1 }
     ]
   },
   {
     "id": "arachnid_acid",
     "type": "harvest",
+    "message": "You carefully crack open its exoskeleton to get at the flesh beneath",
     "entries": [
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.33 },
       { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.04 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.01 },
-      { "drop": "acidchitin_piece", "type": "bone", "mass_ratio": 0.1 }
+      { "drop": "acidchitin_piece", "type": "skin", "mass_ratio": 0.1 }
     ]
   },
   {
     "id": "arachnid_bee",
     "//": "todo: add stinger here and remove drops from death",
     "type": "harvest",
+    "message": "You carefully crack open its exoskeleton to get at the flesh beneath",
     "entries": [
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.33 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.01 },
-      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.1 }
+      { "drop": "chitin_piece", "type": "skin", "mass_ratio": 0.1 }
     ]
   },
   {
     "id": "arachnid_wasp",
     "//": "todo: add stinger here and remove drops from death",
     "type": "harvest",
+    "message": "You carefully crack open its exoskeleton to get at the flesh beneath",
     "entries": [
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.33 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.01 },
-      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.1 }
+      { "drop": "chitin_piece", "type": "skin", "mass_ratio": 0.1 }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR. It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/mod/json/explanation/json_style.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/dev/explanation/code_style.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

## Summary

SUMMARY: Balance "Universally change chitin from bone to skin, and add specific harvest messages for chitinous animals."

## Purpose of change

Currently, chitin is classified as "bone" for _some_ (but not all!) animals with exoskeletons. This means that most animals with exoskeletons cannot be skinned for chitin, and have to be fully butchered as though the chitin were on the animal's _inside._ By changing chitin from bone to skin for every chitinous animal, Players are now able to "skin" the exoskeletons of giant bugs and the like for chitin. 

Furthermore, as a small flavor change, add the same message as when harvesting shellfish ("You carefully crack open its exoskeleton to get at the flesh beneath") for every animal with chitin except acid ant queen (which already had its own) and mutated mammals with chitin armor.

## Describe the solution

Modify harvest.json to change the "type" of "chitin-piece" from "bone" to "skin" for every class of animal.

## Describe alternatives you've considered

None.

## Testing

After the change, went in game to skin a giant wasp, and got 44 chunks of chitin and nothing else.